### PR TITLE
feat!: bump PHP requirements

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -14,9 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - 8.1
-          - 8.2
           - 8.3
+          - 8.4
         dependencies:
           - highest
         stability:

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "psr/http-message": "^1.0|^2.0",
-        "symfony/clock": "^6.3|^7.0"
+        "symfony/clock": "^6.4|^7.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.56",
@@ -29,7 +29,7 @@
         "phpunit/phpunit": "^10.5",
         "psr/cache": "^1.0|^2.0|^3.0",
         "rector/rector": "^1.0",
-        "symfony/phpunit-bridge": "^4.4|^5.0|^6.0|^7.0"
+        "symfony/phpunit-bridge": "^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {
@@ -62,6 +62,6 @@
         "sort-packages": true
     },
     "platform": {
-        "php": "8.1.99"
+        "php": "8.3.99"
     }
 }


### PR DESCRIPTION
This pull request includes updates to the PHP version requirements and dependencies in the project configuration files. The most important changes involve updating the PHP version in the continuous integration workflow and the `composer.json` file.

### PHP Version Updates:

* [`.github/workflows/continuous-integration.yaml`](diffhunk://#diff-208542bbdcc8946dccfcfd7b7ac20705e8c5f382cdb3bd7fe6ecea4e3b9cf04bL17-R18): Updated the PHP versions in the matrix configuration to include version 8.4 and removed versions 8.1 and 8.2.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L21-R23): Updated the required PHP version to "^8.3" and the platform PHP version to "8.3.99". [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L21-R23) [[2]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L65-R65)

### Dependency Updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L21-R23): Updated the `symfony/clock` dependency to "^6.4|^7.0".
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L32-R32): Updated the `symfony/phpunit-bridge` dependency to "^6.0|^7.0".